### PR TITLE
Make `npm run script` uses the local installed typescript compiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/
 npm-debug.log
 *.js

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "fetch.ts",
   "scripts": {
-    "build": "$(npm bin)/tsc fetch.ts --target ES5",
+    "build": "tsc fetch.ts --target ES5",
     "test": "npm run build && node fetch.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   },
   "main": "fetch.ts",
   "scripts": {
-    "build": "tsc fetch.ts --target ES5",
+    "build": "$(npm bin)/tsc fetch.ts --target ES5",
     "test": "npm run build && node fetch.js"
+  },
+  "devDependencies": {
+    "typescript": "^1.4.1"
   }
 }


### PR DESCRIPTION
This change intends to control the target compiler version.